### PR TITLE
fix algorithm behaviour when reaching the minimum intensity

### DIFF
--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStepViewController.m
@@ -398,6 +398,9 @@
     NSNumber *currentKey = [NSNumber numberWithFloat:_currentdBHL];
     ORKdBHLToneAudiometryTransitions *currentTransitionObject = [_transitionsDictionary objectForKey:currentKey];
     if ((currentTransitionObject.userInitiated/currentTransitionObject.totalTransitions >= 0.5) && currentTransitionObject.totalTransitions >= 2) {
+        if (dBHL - _dBHLStepUpSize <= _dBHLMinimumThreshold) {
+            return YES;
+        }
         ORKdBHLToneAudiometryTransitions *previousTransitionObject = [_transitionsDictionary objectForKey:[NSNumber numberWithFloat:(dBHL - _dBHLStepUpSize)]];
         if ((previousTransitionObject.userInitiated/previousTransitionObject.totalTransitions <= 0.5) && (previousTransitionObject.totalTransitions >= 2)) {
             if (currentTransitionObject.totalTransitions == 2) {


### PR DESCRIPTION
When reaching the minimum intensity, the stop condition doesn't attempt to check the lower intensity condition anymore. Previously, this kept the algorithm in a loop presenting the minimum intensity over and over no matter how many times it was acknowledged. 