### PR TITLE
TH-763: dynamic initial level based on previous result

### DIFF
--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryAudioGenerator.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryAudioGenerator.m
@@ -52,6 +52,7 @@
 
 
 #import "ORKdBHLToneAudiometryAudioGenerator.h"
+#import "ORKdBHLToneAudiometryStep.h"
 
 @import AudioToolbox;
 
@@ -207,7 +208,9 @@ static OSStatus ORKdBHLAudioGeneratorZeroTone(void *inRefCon,
     _fadeInDuration = 0.2;
     _rampUp = YES;
     _globaldBHL = dBHL;
-    
+
+    ORKdBHLToneAudiometryStep.logger([NSString stringWithFormat:@"Playing a %d Hz sound at intensity %d dBHL", (int) _frequency, (int) _globaldBHL]);
+
     [self play];
     
 }

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.h
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.h
@@ -48,6 +48,10 @@ ORK_CLASS_AVAILABLE
 
 @property (nonatomic, assign) double initialdBHLValue;
 
+@property (nonatomic, assign) double initialdBHLIncrementValue;
+
+@property (nonatomic, assign) double initialdBHLMaxValue;
+
 @property (nonatomic, assign) double dBHLStepUpSize;
 
 @property (nonatomic, assign) double dBHLStepUpSizeFirstMiss;

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.h
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.h
@@ -70,6 +70,8 @@ ORK_CLASS_AVAILABLE
 
 @property (nonatomic, copy, nullable) NSArray *frequencyList;
 
+@property (atomic, class, nullable) void (^logger)(NSString *message);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.m
@@ -40,6 +40,8 @@
 #define ORKdBHLToneAudiometryTaskDefaultMaxPostStimulusDelay 1.0
 #define ORKdBHLToneAudiometryTaskDefaultTransitionsPerFrequency 20
 #define ORKdBHLToneAudiometryTaskInitialdBHLValue 30.0
+#define ORKdBHLToneAudiometryTaskInitialdBHLIncrementValue 20.0
+#define ORKdBHLToneAudiometryTaskInitialdBHLMaxValue 70.0
 #define ORKdBHLToneAudiometryTaskdBHLStepUpSize 5.0
 #define ORKdBHLToneAudiometryTaskdBHLStepUpSizeFirstMiss 20.0
 #define ORKdBHLToneAudiometryTaskdBHLStepUpSizeSecondMiss 10.0
@@ -67,6 +69,8 @@
     self.postStimulusDelay = ORKdBHLToneAudiometryTaskDefaultMaxPostStimulusDelay;
     self.maxNumberOfTransitionsPerFrequency = ORKdBHLToneAudiometryTaskDefaultTransitionsPerFrequency;
     self.initialdBHLValue = ORKdBHLToneAudiometryTaskInitialdBHLValue;
+    self.initialdBHLIncrementValue = ORKdBHLToneAudiometryTaskInitialdBHLIncrementValue;
+    self.initialdBHLMaxValue = ORKdBHLToneAudiometryTaskInitialdBHLMaxValue;
     self.dBHLStepUpSize = ORKdBHLToneAudiometryTaskdBHLStepUpSize;
     self.dBHLStepUpSizeFirstMiss = ORKdBHLToneAudiometryTaskdBHLStepUpSizeFirstMiss;
     self.dBHLStepUpSizeSecondMiss = ORKdBHLToneAudiometryTaskdBHLStepUpSizeSecondMiss;
@@ -106,6 +110,8 @@
     step.postStimulusDelay = self.postStimulusDelay;
     step.maxNumberOfTransitionsPerFrequency = self.maxNumberOfTransitionsPerFrequency;
     step.initialdBHLValue = self.initialdBHLValue;
+    step.initialdBHLIncrementValue = self.initialdBHLIncrementValue;
+    step.initialdBHLMaxValue = self.initialdBHLMaxValue;
     step.dBHLStepDownSize = self.dBHLStepDownSize;
     step.dBHLStepUpSize = self.dBHLStepUpSize;
     step.dBHLMinimumThreshold = self.dBHLMinimumThreshold;
@@ -125,6 +131,8 @@
         ORK_DECODE_DOUBLE(aDecoder, maxRandomPreStimulusDelay);
         ORK_DECODE_DOUBLE(aDecoder, postStimulusDelay);
         ORK_DECODE_DOUBLE(aDecoder, initialdBHLValue);
+        ORK_DECODE_DOUBLE(aDecoder, initialdBHLIncrementValue);
+        ORK_DECODE_DOUBLE(aDecoder, initialdBHLMaxValue);
         ORK_DECODE_DOUBLE(aDecoder, dBHLStepDownSize);
         ORK_DECODE_DOUBLE(aDecoder, dBHLStepUpSize);
         ORK_DECODE_DOUBLE(aDecoder, dBHLStepUpSizeFirstMiss);
@@ -145,6 +153,8 @@
     ORK_ENCODE_DOUBLE(aCoder, maxRandomPreStimulusDelay);
     ORK_ENCODE_DOUBLE(aCoder, postStimulusDelay);
     ORK_ENCODE_DOUBLE(aCoder, initialdBHLValue);
+    ORK_ENCODE_DOUBLE(aCoder, initialdBHLIncrementValue);
+    ORK_ENCODE_DOUBLE(aCoder, initialdBHLMaxValue);
     ORK_ENCODE_DOUBLE(aCoder, dBHLStepDownSize);
     ORK_ENCODE_DOUBLE(aCoder, dBHLStepUpSize);
     ORK_ENCODE_DOUBLE(aCoder, dBHLStepUpSizeFirstMiss);
@@ -171,6 +181,8 @@
             && (self.postStimulusDelay == castObject.postStimulusDelay)
             && (self.maxNumberOfTransitionsPerFrequency == castObject.maxNumberOfTransitionsPerFrequency)
             && (self.initialdBHLValue == castObject.initialdBHLValue)
+            && (self.initialdBHLIncrementValue == castObject.initialdBHLIncrementValue)
+            && (self.initialdBHLMaxValue == castObject.initialdBHLMaxValue)
             && (self.dBHLStepDownSize == castObject.dBHLStepDownSize)
             && (self.dBHLStepUpSize == castObject.dBHLStepUpSize)
             && (self.dBHLStepUpSizeFirstMiss == castObject.dBHLStepUpSizeFirstMiss)

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStep.m
@@ -51,6 +51,8 @@
 
 @implementation ORKdBHLToneAudiometryStep
 
+static void (^_logger)(NSString *message) = nil;
+
 + (Class)stepViewControllerClass {
     return [ORKdBHLToneAudiometryStepViewController class];
 }
@@ -192,6 +194,14 @@
             && (self.earPreference == castObject.earPreference)
             && ORKEqualObjects(self.headphoneType, castObject.headphoneType)
             && ORKEqualObjects(self.frequencyList, castObject.frequencyList));
+}
+
++ (void (^)(NSString *message))logger {
+    return _logger;
+}
+
++ (void)setLogger:(void (^)(NSString * _Nonnull))logger {
+    _logger = logger;
 }
 
 @end

--- a/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStepViewController.m
+++ b/ResearchKit/ActiveTasks/ORKdBHLToneAudiometryStepViewController.m
@@ -262,7 +262,18 @@
                                                animated:YES];
         
         _numberOfTransitionsPerFreq = 0;
+
         _currentdBHL = [self dBHLToneAudiometryStep].initialdBHLValue;
+        if (_indexOfFreqLoopList > 0) {
+            ORKdBHLToneAudiometryFrequencySample *previousResult = _arrayOfResultSamples[_indexOfFreqLoopList - 1];
+            double previousThreshold = [previousResult calculatedThreshold];
+            if (previousThreshold != ORKInvalidDBHLValue) { // if there was a determined previous threshold
+                _currentdBHL = MIN(previousThreshold + [self dBHLToneAudiometryStep].initialdBHLIncrementValue, [self dBHLToneAudiometryStep].initialdBHLMaxValue);
+            } else if (_arrayOfResultUnits.count < _maxNumberOfTransitionsPerFreq) { // if there was no response for the previous frequency
+                _currentdBHL = [self dBHLToneAudiometryStep].initialdBHLMaxValue;
+            }
+        }
+
         _initialDescent = YES;
         _ackOnce = NO;
         _usingMissingList = YES;


### PR DESCRIPTION
Implement dBHL audiometry algorithm changes so that the initial intensity level presented for a frequency is equal to the threshold determined for the previous frequency plus a certain amount (defaults to 20dB), up to a maximum (defaults to 70 dB HL).

The PR also adds logging support for dBHL audiometry to facilitate testing.